### PR TITLE
Improve script generation for AI image prompts

### DIFF
--- a/js/generator.js
+++ b/js/generator.js
@@ -951,10 +951,20 @@ export function constructPrompt() {
         base += currentLanguage === 'en'
             ? `\n- **PRODUCT VISUAL DNA:** ${visualDna}`
             : `\n- **VISUAL DNA PRODUK:** ${visualDna}`;
-        const dnaRule = currentLanguage === 'en'
-            ? `\n- At the END of each text_to_image_prompt, optionally append ID[brand=...; model=...; must_keep_colors=HEX|HEX|HEX; features=...] ONLY if the scene clearly depicts OUR product (not competitor/before/messy/dirty/greasy/sticky/burnt/old/worn/unbranded).`
-            : `\n- Di AKHIR tiap text_to_image_prompt, tambahkan ID[brand=...; model=...; must_keep_colors=HEX|HEX|HEX; features=...] HANYA jika adegan jelas memperlihatkan produk KITA (bukan kompetitor/sebelum/kotor/lengket/gosong/lama/usang/tanpa brand).`;
-        base += dnaRule;
+        // Model-target aware DNA suffix rule (universal-friendly)
+        const mt = (localStorage.getItem('model_target') || 'auto').toLowerCase();
+        const isBracketless = (mt === 'auto' || mt === 'imagen' || mt === 'flux' || mt === 'nano' || mt === 'nanobanana' || mt === 'nano banana');
+        if (isBracketless) {
+            const dnaRule = currentLanguage === 'en'
+                ? `\n- DNA SUFFIX (UNIVERSAL, NO TOKENS): Do NOT use any bracket tokens. End each text_to_image_prompt with a short natural-language suffix like: "— official <brand model>; exact brand colors <#HEX, #HEX>; identity features: <key features>" ONLY if the scene clearly shows OUR product (not competitor/before/messy/dirty/greasy/sticky/burnt/old/worn/unbranded).`
+                : `\n- DNA SUFFIX (UNIVERSAL, TANPA TOKEN): JANGAN gunakan token kurung. Akhiri tiap text_to_image_prompt dengan akhiran bahasa natural seperti: "— official <brand model>; exact brand colors <#HEX, #HEX>; identity features: <fitur kunci>" HANYA jika adegan jelas memperlihatkan produk KITA (bukan kompetitor/sebelum/kotor/lengket/gosong/lama/usang/tanpa brand).`;
+            base += dnaRule;
+        } else {
+            const dnaRule = currentLanguage === 'en'
+                ? `\n- At the END of each text_to_image_prompt, optionally append ID[brand=...; model=...; must_keep_colors=HEX|HEX|HEX; features=...] ONLY if the scene clearly depicts OUR product (not competitor/before/messy/dirty/greasy/sticky/burnt/old/worn/unbranded).`
+                : `\n- Di AKHIR tiap text_to_image_prompt, tambahkan ID[brand=...; model=...; must_keep_colors=HEX|HEX|HEX; features=...] HANYA jika adegan jelas memperlihatkan produk KITA (bukan kompetitor/sebelum/kotor/lengket/gosong/lama/usang/tanpa brand).`;
+            base += dnaRule;
+        }
 
         // Sinkronisasi visual_idea -> T2I wajib
         const fidelityRule = currentLanguage === 'en'

--- a/js/ui.results.js
+++ b/js/ui.results.js
@@ -777,7 +777,7 @@ export async function applyVariantToScript(card, script, section, newText) {
         // model-specific adaptation: remove bracket ID block for bracketless engines and append natural-language suffix
         try {
             const mt = (localStorage.getItem('model_target') || 'auto').toLowerCase();
-            const isBracketless = (mt === 'imagen' || mt === 'flux' || mt === 'nano' || mt === 'nanobanana' || mt === 'nano banana');
+            const isBracketless = (mt === 'auto' || mt === 'imagen' || mt === 'flux' || mt === 'nano' || mt === 'nanobanana' || mt === 'nano banana');
             if (isBracketless) {
                 const brandMatch = (dna.match(/brand=([^,\s]+)/) || [])[1] || '';
                 const modelMatch = (dna.match(/model=([^,\s]+)/) || [])[1] || '';

--- a/js/utils.js
+++ b/js/utils.js
@@ -647,7 +647,8 @@ export function createCharacterEssence(character) {
         (eyeColor || eyeShape) && `${eyeShape} ${eyeColor} eyes`.trim(),
         brows,
         nose,
-        lips
+        lips,
+        hair && `${hair} hair`
     ].filter(Boolean).join(', ');
     const body = [skin, height].filter(Boolean).join(', ');
     const clothing = outfit ? `Wearing ${outfit}.` : '';


### PR DESCRIPTION
Include hair attributes in character essence and switch to universal, bracketless prompt formatting to improve character consistency and model compatibility.

This PR addresses three user-reported issues:
1.  **Inconsistent characters:** Hair style and color were often missing from prompts. The character essence generation now explicitly includes hair details.
2.  **Non-universal prompts:** The `ID[...]` token format was not compatible with models like Gemini, Imagen, and Nano Banana. The prompt generation now uses natural-language suffixes for these models when `model_target` is 'auto' or explicitly set.
3.  **Inconsistent visual DNA:** The product's visual DNA (brand, model, colors) is now consistently injected using a universal, natural-language suffix for compatible models, ensuring better adherence to product details.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f0e3b79-addb-4535-9fb6-30df88c6caa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f0e3b79-addb-4535-9fb6-30df88c6caa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

