### PR TITLE
Fix mobile image cropping button

### DIFF
--- a/css/visual-fixes.css
+++ b/css/visual-fixes.css
@@ -795,9 +795,27 @@ header {
   flex-direction: column !important;
   overflow-y: auto !important;
 }
+#image-cropper-modal .modal-content .sticky.bottom-0 {
+  position: sticky !important;
+  bottom: 0 !important;
+  z-index: 201 !important; /* above cropper overlay */
+  pointer-events: auto !important;
+}
 #image-cropper-modal img#cropper-target {
   max-height: 60vh;
   width: 100%;
   display: block;
+}
+#image-cropper-modal .cropper-container,
+#image-cropper-modal .cropper-wrap-box,
+#image-cropper-modal .cropper-canvas,
+#image-cropper-modal .cropper-drag-box,
+#image-cropper-modal .cropper-crop-box,
+#image-cropper-modal .cropper-modal {
+  touch-action: none; /* prevent scroll hijack while dragging */
+}
+#image-cropper-modal button#cropper-use-btn,
+#image-cropper-modal button#cropper-skip-btn {
+  -webkit-tap-highlight-color: transparent;
 }
 #image-cropper-modal { z-index: 200 !important; }

--- a/js/generator.js
+++ b/js/generator.js
@@ -92,35 +92,42 @@ export async function handleImageUpload(event) {
             modal.querySelector('.modal-content')?.classList.remove('scale-95');
 
             // LANGKAH BARU: Pilih mode Single atau Multi sebelum cropping
-            const chooser = document.createElement('div');
-            chooser.style.display = 'flex';
-            chooser.style.gap = '8px';
-            chooser.style.margin = '8px 0';
-            chooser.style.flexWrap = 'wrap';
-            const chooseText = document.createElement('div');
-            chooseText.className = 'text-xs text-gray-300';
-            chooseText.textContent = (languageState.current==='en')
-              ? 'Crop mode: choose Single product or Multi areas'
-              : 'Mode crop: pilih Satu produk atau Multi area';
-            const btnSingle = document.createElement('button');
-            btnSingle.type = 'button';
-            btnSingle.className = 'px-2 py-1 rounded bg-blue-600 text-white text-xs';
-            btnSingle.textContent = (languageState.current==='en') ? 'Single Crop' : 'Satu Produk';
-            const btnMulti = document.createElement('button');
-            btnMulti.type = 'button';
-            btnMulti.className = 'px-2 py-1 rounded bg-emerald-600 text-white text-xs';
-            btnMulti.textContent = (languageState.current==='en') ? 'Multi Crop' : 'Multi Crop';
-            chooser.append(chooseText, btnSingle, btnMulti);
+            // Mobile UX: default ke Single agar tombol segera berfungsi
+            const isMobileViewport = window.innerWidth < 768;
             const contentNode = modal.querySelector('.modal-content') || modal;
-            contentNode.insertBefore(chooser, contentNode.firstChild);
+            if (!isMobileViewport) {
+                const chooser = document.createElement('div');
+                chooser.style.display = 'flex';
+                chooser.style.gap = '8px';
+                chooser.style.margin = '8px 0';
+                chooser.style.flexWrap = 'wrap';
+                const chooseText = document.createElement('div');
+                chooseText.className = 'text-xs text-gray-300';
+                chooseText.textContent = (languageState.current==='en')
+                  ? 'Crop mode: choose Single product or Multi areas'
+                  : 'Mode crop: pilih Satu produk atau Multi area';
+                const btnSingle = document.createElement('button');
+                btnSingle.type = 'button';
+                btnSingle.className = 'px-2 py-1 rounded bg-blue-600 text-white text-xs';
+                btnSingle.textContent = (languageState.current==='en') ? 'Single Crop' : 'Satu Produk';
+                const btnMulti = document.createElement('button');
+                btnMulti.type = 'button';
+                btnMulti.className = 'px-2 py-1 rounded bg-emerald-600 text-white text-xs';
+                btnMulti.textContent = (languageState.current==='en') ? 'Multi Crop' : 'Multi Crop';
+                chooser.append(chooseText, btnSingle, btnMulti);
+                contentNode.insertBefore(chooser, contentNode.firstChild);
 
-            await new Promise((resolve) => {
-                const pick = (isMulti) => { multiMode = !!isMulti; btnSingle.removeEventListener('click', onSingle); btnMulti.removeEventListener('click', onMulti); chooser.remove(); resolve(); };
-                const onSingle = ()=> pick(false);
-                const onMulti = ()=> pick(true);
-                btnSingle.addEventListener('click', onSingle, { once:true });
-                btnMulti.addEventListener('click', onMulti, { once:true });
-            });
+                await new Promise((resolve) => {
+                    const pick = (isMulti) => { multiMode = !!isMulti; btnSingle.removeEventListener('click', onSingle); btnMulti.removeEventListener('click', onMulti); chooser.remove(); resolve(); };
+                    const onSingle = ()=> pick(false);
+                    const onMulti = ()=> pick(true);
+                    btnSingle.addEventListener('click', onSingle, { once:true });
+                    btnMulti.addEventListener('click', onMulti, { once:true });
+                });
+            } else {
+                // Default ke single-crop di mobile untuk menghindari langkah ekstra yang bisa membingungkan
+                multiMode = false;
+            }
 
             await new Promise((resolve) => setTimeout(resolve, 50));
             try { cropper?.destroy(); } catch(_) {}


### PR DESCRIPTION
Fix unresponsive image cropping buttons on mobile by streamlining the workflow and ensuring button tapability.

On mobile, the crop mode chooser is now skipped, defaulting to single-crop to immediately activate the cropper. CSS adjustments ensure the sticky footer buttons are positioned above the cropper overlay with correct `z-index` and `pointer-events`, and `touch-action: none` prevents scroll interference during cropping.

---
<a href="https://cursor.com/background-agent?bcId=bc-df1e1d9e-41e2-46f4-b411-5a8b0d0f4ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df1e1d9e-41e2-46f4-b411-5a8b0d0f4ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

